### PR TITLE
Let's put the fqdn in the thing

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,7 @@ platforms:
     customize:
       cpus: 1
       memory: 256
+    vm_hostname: test.example.com
 suites:
 - name: noipv6
   run_list:

--- a/templates/default/network.erb
+++ b/templates/default/network.erb
@@ -1,4 +1,3 @@
 NETWORKING=yes
 NETWORKING_IPV6=no
-HOSTNAME=<%= node['hostname'] %>
-GATEWAY=<%= node['network']['default_gateway'] %>
+HOSTNAME=<%= node['fqdn'] %>

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,10 +1,3 @@
 require 'serverspec'
 
-include Serverspec::Helper::DetectOS
-include Serverspec::Helper::Exec
-
-RSpec.configure do |c|
-  c.before :all do
-    c.os = backend(Serverspec::Commands::Base).check_os
-  end
-end
+set :backend, :exec


### PR DESCRIPTION
* Uses the full fqdn vs just the hostname which is the default
* Fixes the spec test
* Fixes the test kitchen to actually find the centos image
* Also removes the gateway configuration
  * Why is this in here anyways?